### PR TITLE
rt#86812 Net::SSL fails to recieve last chunk of body from some servers

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -284,6 +284,7 @@ sub can_read {
     my $self = shift;
     return 1 unless defined(fileno($self));
     return 1 if $self->isa('IO::Socket::SSL') && $self->pending;
+    return 1 if $self->isa('Net::SSL') && $self->pending;
 
     # With no timeout, wait forever.  An explict timeout of 0 can be
     # used to just check if the socket is readable without waiting.


### PR DESCRIPTION
This fix for rt#86812 is dependant upon pull request https://github.com/nanis/Crypt-SSLeay/pull/2 for rt#86819. I've basically replicated the fix for IO::Socket::SSL, however I have a feeling that the fixes for both of these should really live in Net::HTTPS. I guess there could be tests for these fixes with mocking the SSLeay objects under IO::Socket::SSL and Net::SSL, but I'd rather have some feed back from the maintainers on how they would like to procede here before delving too deeply on that one.
