### PR TITLE
fix-net-ssl-1

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -284,6 +284,7 @@ sub can_read {
     my $self = shift;
     return 1 unless defined(fileno($self));
     return 1 if $self->isa('IO::Socket::SSL') && $self->pending;
+    return 1 if $self->isa('Net::SSL') && $self->pending;
 
     # With no timeout, wait forever.  An explict timeout of 0 can be
     # used to just check if the socket is readable without waiting.


### PR DESCRIPTION
Net::HTTP is broken when use with Net::SSL since version 6.03

Net::SSL 2.86 now have the pending method.
This patch fix Net::HTTP when use with Net::SSL 2.86
