### PR TITLE
Allow peer addresses to have multiple colons for ipv6

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -44,7 +44,8 @@ sub http_configure {
 	$cnf->{PeerAddr} = $peer = $host;
     }
 
-    if ($peer =~ s,:(\d+)$,,) {
+    # if ipv6 don't override 
+    if ($peer !~ m/:(.*):/ && $peer =~ s,:(\d+)$,,) {
 	$cnf->{PeerPort} = int($1);  # always override
     }
     if (!$cnf->{PeerPort}) {


### PR DESCRIPTION
ipv6 ips aren't working because the colon existence is assuming a port was passed in. Here is a demo using LWP::Simple which fails without this patch:
# !/usr/local/bin/perl

use Net::INET6Glue::INET_is_INET6;
use LWP::Simple;
my $ua = new LWP::UserAgent;
my $url = 'http://[2001:4998:c:401::c:9101]/';
print "Attempting to fetch: $url\n";
my $response = $ua->get( $url );
if ($response->is_success) {
        print $response->decoded_content;
} else {
        print STDERR $response->status_line, "\n";
}
