### PR TITLE
take more care with v6 literals and port numbers

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -46,7 +46,7 @@ sub http_configure {
 
     # $cnf->{Family} is not necessarily set here, or we could check AF_INET6
     # square bracket followed by colon is almost certainly a v6 literal with a port number
-    if ($peer =~ /]:/ && $peer =~ s,]:(\d+)$,,) {
+    if ($peer =~ s,]:(\d+)$,,) {
         $cnf->{PeerPort} = int($1);
     }
     # assume multiple colons in a string is a bare v6 literal, and don't touch it


### PR DESCRIPTION
being very careful around v6 literals and how to parse out a port number within this function. In principle, valid strings could be of the form:
1. `hostname`
2. `hostname:port`
3. `a.b.c.d`
4. `a.b.c.d:port`
5. `a:b:c:d:e::f`
6. `[a:b:c:d:e::f]`
7. `[a:b:c:d:e::f]:port`

The logic in this pull request is:
1. if the string contains square brackets (6 & 7 above), attempt to parse the port after the closing bracket
2. otherwise, if the string doesn't contain multiple colons (1 through 5 above), attempt to parse out the port number according to the old semantics
3. otherwise, don't touch the PeerPort variable at all

h/t to @sc0ttbeardsley and https://github.com/libwww-perl/net-http/pull/8/files for catching that case!
