### PR TITLE
use like() instead of is() for regex checking responses

### DIFF
--- a/t/apache-https.t
+++ b/t/apache-https.t
@@ -66,7 +66,7 @@ for (1..2) {
     is($code, "200");
     is($h{'Content-Type'}, "message/http");
 
-    is($buf, qr/^TRACE \/libwww-perl HTTP\/1/);
-    is($buf, qr/^User-Agent: Mozilla\/5.0$/m);
+    like($buf, qr/^TRACE \/libwww-perl HTTP\/1/);
+    like($buf, qr/^User-Agent: Mozilla\/5.0$/m);
 }
 

--- a/t/apache.t
+++ b/t/apache.t
@@ -60,7 +60,7 @@ for (1..2) {
     is($code, "200");
     is($h{'Content-Type'}, "message/http");
 
-    is($buf, qr/^TRACE \/libwww-perl HTTP\/1/);
-    is($buf, qr/^User-Agent: Mozilla\/5.0$/m);
+    like($buf, qr/^TRACE \/libwww-perl HTTP\/1/);
+    like($buf, qr/^User-Agent: Mozilla\/5.0$/m);
 }
 


### PR DESCRIPTION
Not sure how/when is($got, $regex) ever worked but like() seems the right way to do it...