### PR TITLE
Fix RT#112313 - Hang in my_readline() when keep-alive => 1 and $reponse_size % 1024 == 0

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -277,6 +277,8 @@ sub my_readline {
                     if(defined $bytes_read) {
                         $new_bytes += $bytes_read;
                         last if $bytes_read < 1024;
+                        # We got exactly 1024 bytes, so we need to select() to know if there is more data
+                        last unless $self->can_read(0);
                     }
                     elsif($!{EINTR} || $!{EAGAIN} || $!{EWOULDBLOCK}) {
                         redo READ;


### PR DESCRIPTION
my_readline() is broken for response sizes (headers + raw body) that are multiples of 1024 (sysread block size).

When reading from date from the socket, we keep reading until we get fewer bytes than we asked for. The code implicitly assumes that if we're getting _exactly_ what we asked for, then there is more data available. That assumption does not hold true for response sizes of 1024, 2048, etc...

In most cases, this bug is masked by either not using keep-alive or by a lot of servers having short keep-alive timeouts. It is easily reproducible though by using a simple Plack one-liner and tweaking the response size until hitting e.g. 1024 bytes in the first sysread(). The following works with starman:

```
$ cat foo.psgi
sub { [ 200, [], [ "x" x 904 ] ] } # Tweak response size as needed, depending on headers sent by starman
$
$ starman --keepalive-timeout 10 foo.psgi
```

Elsewhere, run:

```
$ time perl -MLWP::UserAgent -e 'print LWP::UserAgent->new(keep_alive => 1)->post(q(http://127.0.0.1:5000))->status_line'
200 OK
real    0m10.067s
user    0m0.052s
sys 0m0.004s
$
```

Net::HTTP hangs, waiting for more data until the server disconnects.

The simplest fix seems to be just checking can_read() before another read if we get exactly what we asked for in sysread().
