### PR TITLE
use EWOULDBLOCK additionally on all places where EAGAIN is used

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -321,8 +321,8 @@ sub can_read {
         $before = time if $timeout;
         my $nfound = select($fbits, undef, undef, $timeout);
         if ($nfound < 0) {
-            if ($!{EINTR} || $!{EAGAIN}) {
-                # don't really think EAGAIN can happen here
+            if ($!{EINTR} || $!{EAGAIN} || $!{EWOULDBLOCK}) {
+                # don't really think EAGAIN/EWOULDBLOCK can happen here
                 if ($timeout) {
                     $timeout -= time - $before;
                     $timeout = 0 if $timeout < 0;


### PR DESCRIPTION
This is a continuation of https://github.com/libwww-perl/Net-HTTP/pull/11 because my attempt to rebase the 2 year old pull request resulted in a mess. Note that the major part of the orginal pull request was already fixed and this new pull request adds a fix on a place where EAGAIN or EWOULDBLOCK would probably not happen anyway.