### PR TITLE
Fix a bug where downloading files is sometimes very slow

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -269,23 +269,17 @@ sub my_readline {
                      or die "read timeout";
 
                 # consume all incoming bytes
-                while(1) {
-                    my $bytes_read = $self->sysread($_, 1024, length);
-                    if(defined $bytes_read) {
-                        $new_bytes += $bytes_read;
-                        last if $bytes_read < 1024;
-                        # We got exactly 1024 bytes, so we need to select() to know if there is more data
-                        last unless $self->can_read(0);
-                    }
-                    elsif($!{EINTR} || $!{EAGAIN} || $!{EWOULDBLOCK}) {
-                        redo READ;
-                    }
-                    else {
-                        # if we have already accumulated some data let's at
-                        # least return that as a line
-                        length or die "$what read failed: $!";
-                        last;
-                    }
+                my $bytes_read = $self->sysread($_, 1024, length);
+                if(defined $bytes_read) {
+                    $new_bytes += $bytes_read;
+                }
+                elsif($!{EINTR} || $!{EAGAIN} || $!{EWOULDBLOCK}) {
+                    redo READ;
+                }
+                else {
+                    # if we have already accumulated some data let's at
+                    # least return that as a line
+                    length or die "$what read failed: $!";
                 }
 
                 # no line-ending, no new bytes


### PR DESCRIPTION
I'm using LWP::UserAgent (and Net::HTTP) for downloading large files.
Then I realized that downloading files sometimes took a lot of time and used a lot of memory.

## How to reproduce this issue

I assume you use Linux.

#### (1) Prepare a 100MB file, and start HTTP server:
```
❯ dd if=/dev/zero of=file.txt bs=10M count=10

❯ ls -alh file.txt
-rw-rw-r-- 1 skaji skaji 100M Apr 17 01:19 file.txt

❯ plackup -MPlack::App::File -e 'Plack::App::File->new(file => "file.txt")->to_app'
HTTP::Server::PSGI: Accepting connections at http://0:5000/
```

#### (2) Prepare the following script, which downloads file.txt to out.txt
```perl
# download.pl
use strict;
use warnings;
use LWP::UserAgent;
use HTTP::Request;
my $req = HTTP::Request->new("GET", "http://localhost:5000");
my $res = LWP::UserAgent->new->request($req, "out.txt");
```

#### (3) Execute download.pl with time and strace command **several times**.
```
❯ time bash -c 'strace perl download.pl 2>&1 | grep read'
```
Then you will see two cases.
In one case (a), you'll see `read(3, ...4096) = 4096` repeatedly, which is expected and takes 6~7sec. 
```
❯ time bash -c 'strace perl download.pl 2>&1 | grep read'
...
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
...
bash -c 'strace perl download.pl 2>&1 | grep read'  1.87s user 2.58s system 70% cpu 6.310 total
```

In the other case (b), you'll see `read(3, ...1024) = 1024` repeatedly, which is **unexpected**, takes 20+sec, and uses a lot of memory.

```
❯ time bash -c 'strace perl download.pl 2>&1 | grep read'
...
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 1024) = 1024
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 1024) = 1024
read(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 1024) = 1024
...
bash -c 'strace perl download.pl 2>&1 | grep read'  5.22s user 9.71s system 71% cpu 20.975 total
```

## What is the problem?

Net::HTTP::Methods uses my_readline() to read data from socket when it expect "line" data such as HTTP Status line, HTTP Header line, and it keep data in memory.

In current implementation of my_readline(), if `$sock->sysread($buf, 1024)` returns exactly 1024, then it will retry sysread() again.
I don't see any reason to retry sysread() here, and if we retry sysread(), all data is stored in memory.

Note that we check whether we have "line" data or not at https://github.com/libwww-perl/Net-HTTP/blob/master/lib/Net/HTTP/Methods.pm#L258-L259

## How to fix the problem

Do not retry sysread() when `$sock->sysread($buf, 1024) == 1024`.

## See also

Commits related to my_readline()

https://github.com/libwww-perl/Net-HTTP/commit/8311cd11544f59100d1f135e63007b8f3ded50d9
https://github.com/libwww-perl/Net-HTTP/commit/01f7937ad1802531c1efa79e3d8361f3e5007733