### PR TITLE
www.google.com -> www.cpan.org

### DIFF
--- a/t/live-https.t
+++ b/t/live-https.t
@@ -6,13 +6,13 @@ BEGIN {
     eval {
         require IO::Socket::INET;
         my $s = IO::Socket::INET->new(
-            PeerHost => "www.google.com:443",
+            PeerHost => "www.cpan.org:443",
             Timeout  => 5,
         );
         die "Can't connect: $@" unless $s;
     };
     if ($@) {
-        print "1..0 # SKIP Can't connect to www.google.com:443\n";
+        print "1..0 # SKIP Can't connect to www.cpan.org:443\n";
         print $@;
         exit;
     }
@@ -32,7 +32,7 @@ plan tests => 6;
 use Net::HTTPS;
 
 my $s = Net::HTTPS->new(
-    Host            => "www.google.com",
+    Host            => "www.cpan.org",
     KeepAlive       => 1,
     Timeout         => 15,
     PeerHTTPVersion => "1.1",

--- a/t/live.t
+++ b/t/live.t
@@ -6,13 +6,13 @@ BEGIN {
     eval {
         require IO::Socket::INET;
         my $s = IO::Socket::INET->new(
-            PeerHost => "www.google.com:80",
+            PeerHost => "www.cpan.org:80",
             Timeout  => 5,
         );
         die "Can't connect: $@" unless $s;
     };
     if ($@) {
-        print "1..0 # SKIP Can't connect to www.google.com\n";
+        print "1..0 # SKIP Can't connect to www.cpan.org\n";
         print $@;
         exit;
     }
@@ -26,7 +26,7 @@ plan tests => 6;
 use Net::HTTP;
 
 my $s = Net::HTTP->new(
-    Host            => "www.google.com",
+    Host            => "www.cpan.org",
     KeepAlive       => 1,
     Timeout         => 15,
     PeerHTTPVersion => "1.1",


### PR DESCRIPTION
`www.google.com` sometimes gets redirected to `www.google.xxx`, so tests may fail. 
```
❯ prove -l t/live.t
t/live.t .. 1/6
#   Failed test at t/live.t line 64.
#          got: '302'
#     expected: '200'

#   Failed test at t/live.t line 66.
#                   '<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
# <TITLE>302 Moved</TITLE></HEAD><BODY>
# <H1>302 Moved</H1>
# The document has moved
# <A HREF="http://www.google.co.jp/?gfe_rd=cr&amp;ei=u6fzWInsLYOM4gLuuZuYDA">here</A>.
# </BODY></HTML>
```
Why don't you use `www.cpan.org` instead?