### PR TITLE
Bump IO::Socket::SSL version from 1.38 to 2.012

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Release history for {{$dist->name}}
 
 {{$NEXT}}
+    - Bump IO::Socket::SSL version from 1.38 to 2.012
 
 6.15      2017-05-12 14:57:02+02:00 Europe/Paris
     - Fix t/rt-112313.t (Shoichi Kaji)

--- a/META.json
+++ b/META.json
@@ -46,7 +46,7 @@
             "IO::Socket" : "0",
             "IO::Socket::INET6" : "0",
             "IO::Socket::IP" : "0",
-            "IO::Socket::SSL" : "1.38",
+            "IO::Socket::SSL" : "2.012",
             "Symbol" : "0"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ requires "warnings" => "0";
 suggests "IO::Socket" => "0";
 suggests "IO::Socket::INET6" => "0";
 suggests "IO::Socket::IP" => "0";
-suggests "IO::Socket::SSL" => "1.38";
+suggests "IO::Socket::SSL" => "2.012";
 suggests "Symbol" => "0";
 
 on 'test' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -29,7 +29,7 @@ perl = 5.006002
 skip = Net::SSL
 
 [Prereqs / RuntimeSuggests]
-IO::Socket::SSL = 1.38
+IO::Socket::SSL = 2.012
 
 [Prereqs::Soften]
 to_relationship = suggests


### PR DESCRIPTION
Fixes #47

This is to fix a live test error:

t/live-https.t ......... Net::HTTPS: SSL connect attempt failed with
unknown errorerror:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1
alert protocol version at t/live-https.t line 34.

See https://github.com/libwww-perl/Net-HTTP/issues/47