### PR TITLE
PRC - May 2017

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -641,4 +641,4 @@ sub inflate_ok {
 
 __END__
 
-# ABSTRACT: Represents method for Net::HTTP
+# ABSTRACT: Methods shared by Net::HTTP and Net::HTTPS

--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -638,3 +638,7 @@ sub inflate_ok {
 } # BEGIN
 
 1;
+
+__END__
+
+# ABSTRACT: Represents method for Net::HTTP


### PR DESCRIPTION
Hi @oalders 

Please review the PR done as a part of PRC.
This removes minor warning during build complaining about missing abstract in the package Net::HTTP::Methods.

[DZ] beginning to build Net-HTTP
[@Author::OALDERS/PodWeaver] [@Default/Name] couldn't find abstract in lib/Net/HTTP/Methods.pm

Many Thanks.
Best Regards,
Mohammad S Anwar