### PR TITLE
Switch to GitHub workflows

### DIFF
--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -1,0 +1,127 @@
+---
+name: dzil build and test
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "15 4 * * 0" # Every Sunday morning
+
+jobs:
+  build-job:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:5.32
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Tests
+        env:
+          AUTHOR_TESTING: 1
+          AUTOMATED_TESTING: 1
+          EXTENDED_TESTING: 1
+          RELEASE_TESTING: 1
+        run: auto-build-and-test-dist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build_dir
+          path: build_dir
+        if: ${{ github.actor != 'nektos/act' }}
+  coverage-job:
+    needs: build-job
+    runs-on: ubuntu-latest
+    container:
+      image: perldocker/perl-tester:5.32
+    steps:
+      - uses: actions/checkout@v2 # codecov wants to be inside a Git repository
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: Install deps and test
+        run: cpan-install-dist-deps && test-dist
+        env:
+          AUTHOR_TESTING: 1
+          AUTOMATED_TESTING: 1
+          EXTENDED_TESTING: 1
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+  httpbin-job:
+    needs: build-job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: Pull httpbin Docker image
+        run: docker pull kennethreitz/httpbin
+      - name: Run httpbin
+        run: docker run -d -p 31234:80 kennethreitz/httpbin
+      - name: docker pull perldocker/perl-tester:5.32
+        run: docker pull perldocker/perl-tester:5.32
+      - name: Run tests via Docker
+        run: >
+          docker run
+          --network="host"
+          --env AUTHOR_TESTING=1
+          -v
+          $(pwd):/home/dist perldocker/perl-tester:5.32
+          /bin/sh -c "cd /home/dist && cpan-install-dist-deps && prove -lv xt/rt-112313.t"
+  test-job:
+    needs: build-job
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        perl-version:
+          - "5.8"
+          - "5.10"
+          - "5.12"
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+        exclude:
+          - os: windows-latest
+            perl-version: "5.8"
+          - os: windows-latest
+            perl-version: "5.10"
+          - os: windows-latest
+            perl-version: "5.12"
+          - os: windows-latest
+            perl-version: "5.14"
+          - os: windows-latest
+            perl-version: "5.16"
+          - os: windows-latest
+            perl-version: "5.32"
+    name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
+    steps:
+      - name: Set Up Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+          distribution: strawberry # this option only used on Windows
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          cpanfile: "cpanfile"
+          args: "--with-suggests --with-recommends --with-test"
+      - run: prove -l t xt
+        env:
+          AUTHOR_TESTING: 1
+          RELEASE_TESTING: 1

--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,13 @@ perl = 5.006002
 -remove = Test::Synopsis
 -remove = Test::TidyAll
 -remove = StaticInstall
+-remove = Test::Pod::Coverage::Configurable
+
+[Test::Pod::Coverage::Configurable]
+trustme = Net::HTTP::Methods => qr/.*/
+trustme = Net::HTTP => qr/^(configure|http_connect)$/
+trustme = Net::HTTP::NB => qr/^(can_read|sysread)$/
+trustme = Net::HTTPS => qr/^(configure|http_connect|http_default_port)$/
 
 [AutoPrereqs]
 skip = Net::SSL

--- a/lib/Net/HTTP.pm
+++ b/lib/Net/HTTP.pm
@@ -67,7 +67,7 @@ HTTP protocol is described in RFC 2616.  The C<Net::HTTP> class
 supports C<HTTP/1.0> and C<HTTP/1.1>.
 
 C<Net::HTTP> is a sub-class of one of C<IO::Socket::IP> (IPv6+IPv4),
-C<IO::Socket::INET6> (IPv6+IPv4), or C<IO::Socket::INET> (IPv4 only).  
+C<IO::Socket::INET6> (IPv6+IPv4), or C<IO::Socket::INET> (IPv4 only).
 You can mix the methods described below with reading and writing from the
 socket directly.  This is not necessary a good idea, unless you know what
 you are doing.
@@ -164,7 +164,7 @@ format_request().  Returns true if successful.
 
 =item $s->format_chunk( $data )
 
-Returns the string to be written for the given chunk of data.  
+Returns the string to be written for the given chunk of data.
 
 =item $s->write_chunk($data)
 

--- a/xt/rt-112313.t
+++ b/xt/rt-112313.t
@@ -1,3 +1,8 @@
+# This test requires a locally deployed httpbin
+#
+# $ docker pull kennethreitz/httpbin
+# $ docker run -p 31234:80 kennethreitz/httpbin
+
 BEGIN {
   if ( $ENV{NO_NETWORK_TESTING} ) {
     print "1..0 # SKIP Live tests disabled due to NO_NETWORK_TESTING\n";
@@ -6,13 +11,13 @@ BEGIN {
   eval {
         require IO::Socket::INET;
         my $s = IO::Socket::INET->new(
-            PeerHost => "httpbin.org:80",
+            PeerHost => "localhost:31234",
             Timeout  => 5,
         );
         die "Can't connect: $@" unless $s;
   };
   if ($@) {
-        print "1..0 # SKIP Can't connect to httpbin.org\n";
+        print "1..0 # SKIP Can't connect to localhost\n";
         print $@;
         exit;
   }
@@ -42,7 +47,7 @@ sub try
 
     # Need a new socket every time because we're testing with Keep-Alive...
     my $s = Net::HTTP->new(
-        Host            => "httpbin.org",
+        Host            => "localhost:31234",
         KeepAlive       => 1,
         PeerHTTPVersion => "1.1",
     ) or die "$@";

--- a/xt/rt-112313.t
+++ b/xt/rt-112313.t
@@ -23,7 +23,7 @@ use warnings;
 use Test::More;
 use Net::HTTP;
 
-# Attempt to verify that RT#112313 (Hang in my_readline() when keep-alive => 1 and $reponse_size % 1024 == 0) is fixed
+# Attempt to verify that RT#112313 (Hang in my_readline() when keep-alive => 1 and $response_size % 1024 == 0) is fixed
 
 # To do that, we need responses (headers + body) that are even multiples of 1024 bytes. So we
 # iterate over the same URL, trying to grow the response size incrementally...
@@ -32,7 +32,7 @@ use Net::HTTP;
 # the Content-Length also rolls over to one more digit, thus increasing the total response by two
 # bytes.
 
-# So, we check that the reponse growth is only one byte after each iteration and also test multiple
+# So, we check that the response growth is only one byte after each iteration and also test multiple
 # times across the 1024, 2048 and 3072 boundaries...
 
 
@@ -109,7 +109,7 @@ for my $kb (1024, 2048, 3072)
             or diag("error: $@");
 
         # Verify that response length only increased by one since the whole test rests on that assumption...
-        is($len - $last, 1, 'reponse length increased by 1') if $last;
+        is($len - $last, 1, 'response length increased by 1') if $last;
 
         $last = $len;
     }


### PR DESCRIPTION
Closes #65 

This adds GitHub workflows. As part of the change it adds an additional build which runs only the test which required httpbin.org  That site doesn't actually support our use case -- it's not set up to be used by testing environments. So, I've used their Docker image to be able to run the test against a local httpbin. Now we will no longer rely on network requests for that particular test.

Currently the httpbin build runs a single test file on a single Perl version. We could expand this if needed, but for now I think it's probably good enough.