### PR TITLE
Replace last use of "vars" with "our"

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,6 @@
             "base" : "0",
             "perl" : "5.006002",
             "strict" : "0",
-            "vars" : "0",
             "warnings" : "0"
          },
          "suggests" : {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,6 @@ my %WriteMakefileArgs = (
     "URI" => 0,
     "base" => 0,
     "strict" => 0,
-    "vars" => 0,
     "warnings" => 0
   },
   "TEST_REQUIRES" => {
@@ -56,7 +55,6 @@ my %FallbackPrereqs = (
   "URI" => 0,
   "base" => 0,
   "strict" => 0,
-  "vars" => 0,
   "warnings" => 0
 );
 

--- a/cpanfile
+++ b/cpanfile
@@ -6,7 +6,6 @@ requires "URI" => "0";
 requires "base" => "0";
 requires "perl" => "5.006002";
 requires "strict" => "0";
-requires "vars" => "0";
 requires "warnings" => "0";
 suggests "IO::Socket" => "0";
 suggests "IO::Socket::INET6" => "0";

--- a/lib/Net/HTTP.pm
+++ b/lib/Net/HTTP.pm
@@ -3,7 +3,7 @@ our $VERSION = '6.20';
 use strict;
 use warnings;
 
-use vars qw($SOCKET_CLASS);
+our $SOCKET_CLASS;
 unless ($SOCKET_CLASS) {
     # Try several, in order of capability and preference
     if (eval { require IO::Socket::IP }) {

--- a/lib/Net/HTTPS.pm
+++ b/lib/Net/HTTPS.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 # Figure out which SSL implementation to use
-use vars qw($SSL_SOCKET_CLASS);
+our $SSL_SOCKET_CLASS;
 if ($SSL_SOCKET_CLASS) {
     # somebody already set it
 }

--- a/t/socket-class.t
+++ b/t/socket-class.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+{
+    $Net::HTTP::SOCKET_CLASS = 'Foo';
+
+    require Net::HTTP;
+
+    is $Net::HTTP::SOCKET_CLASS, 'Foo';
+
+    is_deeply \@Net::HTTP::ISA, [qw[Foo Net::HTTP::Methods]];
+}
+
+{
+    $Net::HTTPS::SSL_SOCKET_CLASS = 'Foo';
+
+    require Net::HTTPS;
+
+    is $Net::HTTPS::SSL_SOCKET_CLASS, 'Foo';
+
+    is_deeply \@Net::HTTPS::ISA, [qw[Foo Net::HTTP::Methods]];
+}
+
+
+done_testing;


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under v5.6+.

This dist depends on v5.6+ and already uses "our" elsewhere.