### PR TITLE
Accept PeerAddr of 0.

### DIFF
--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -35,8 +35,14 @@ sub http_configure {
     die "Listen option not allowed" if $cnf->{Listen};
     my $explicit_host = (exists $cnf->{Host});
     my $host = delete $cnf->{Host};
-    my $peer = $cnf->{PeerAddr} || $cnf->{PeerHost};
-    if (!$peer) {
+    # All this because $cnf->{PeerAddr} = 0 is actually valid.
+    my $peer;
+    for my $key (qw{PeerAddr PeerHost}) {
+	next if !defined($cnf->{$key}) || q{} eq $cnf->{$key};
+	$peer = $cnf->{$key};
+	last;
+    }
+    if (!defined $peer) {
 	die "No Host option provided" unless $host;
 	$cnf->{PeerAddr} = $peer = $host;
     }

--- a/t/http.t
+++ b/t/http.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 
-plan tests => 37;
+plan tests => 38;
 #use Data::Dump ();
 
 my $CRLF = "\015\012";
@@ -204,3 +204,13 @@ eval {
 print "# $@";
 ok($@);
 
+$@ = '';
+eval {
+    $h = HTTP->new(
+	PeerAddr	=> 0,
+	PeerPort	=> 5000,
+	Proto		=> 'tcp',
+    );
+};
+print '# $@ is ', $@ ? $@ : "''\n";
+ok(!$@);


### PR DESCRIPTION
This turned up while messing with a little Dancer2 app. The startup
notification said 'Accepting connections at http://0:5000/', and the
curl program is fine with that. But LWP::UserAgent was not, complaining
that 'No Host option provided'.

I tracked this to Net::HTTP::Methods, specifically its http_configure()
method, which was called with $cnf = { ..., PeerAddr => 0, ... }. It
computes

  my $peer = $cnf->{PeerAddr} || $cnf->{PeerHost};

and dies with the given message if $peer is false.

The patch iterates over PeerAddr and PeerHost and sets $peer to the
first found which is defined and not the empty string. I have installed
this on my system, and LWP::UserAgent is now happy with
'http://0:5000/'.

Now, I do not claim to know if a host of '0' is official in any way, but
the fact that Dancer2 requests it and curl accepts it looks to me like a
pragmatic reason to handle it.

I was unable to get Perl 5.6.2 configured for testing, but the modified
code does pass under 5.8.4, at least on my box. For what it is worth,
perlver says the syntax is good back to 5.6.0.