### PR TITLE
Bump copyright year to current release year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2001-2017 by Gisle Aas.
+This software is copyright (c) 2001-2021 by Gisle Aas.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2001-2017 by Gisle Aas.
+This software is Copyright (c) 2001-2021 by Gisle Aas.
 
 This is free software, licensed under:
 
@@ -272,7 +272,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2001-2017 by Gisle Aas.
+This software is Copyright (c) 2001-2021 by Gisle Aas.
 
 This is free software, licensed under:
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Gisle Aas <gisle@activestate.com>
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2001-2017 by Gisle Aas.
+This software is copyright (c) 2001-2021 by Gisle Aas.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author  = Gisle Aas <gisle@activestate.com>
 license = Perl_5
 main_module = lib/Net/HTTP.pm
 copyright_holder = Gisle Aas
-copyright_year   = 2001-2017
+copyright_year   = 2001-2021
 
 [MetaResources]
 x_IRC = irc://irc.perl.org/#lwp


### PR DESCRIPTION
While looking through the README I noticed that the copyright year
didn't match the year of the most recent release.  This commit updates
the values to match each other.

This PR is submitted in the hope that it is useful. If you want anything changed, please just let me know and I'm more than happy to update it and resubmit as necessary.

One thing that I was wondering: is the copyright holder still correct? Is Giles Aas still the copyright hoder, or should this be extended or changed in some way?