### PR TITLE
Ignore automatically generated directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ xx*
 /Net-HTTP-*.tar.gz
 t/LIVE_TESTS
 .tidyall.d
+/local/
+/cover_db/


### PR DESCRIPTION
When installing the dependencies with `cpm` I noticed that the `local/`
directory is created automatically and doesn't need to be checked in to
the repository, hence it can be ignored so that the working directory
remains clean.  The same is for the `cover_db/` directory which is
created when generating coverage information.

If you would like any changes, please let me know and I'll be happy to update the PR and resubmit as appropriate.