### PR TITLE
Tune CI: modernize Perl workflow and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -10,6 +10,10 @@ on:
       - "*"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-job:
     name: Build distribution

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -70,7 +70,7 @@ jobs:
     needs: build-job
     runs-on: "ubuntu-latest"
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         perl-version:
@@ -109,7 +109,7 @@ jobs:
     needs: ubuntu-test-job
     runs-on: "macos-latest"
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [macos-latest]
         perl-version:

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -86,6 +86,9 @@ jobs:
           - "5.32"
           - "5.34"
           - "5.36"
+          - "5.38"
+          - "5.40"
+          - "5.42"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl
@@ -123,6 +126,10 @@ jobs:
           - "5.28"
           - "5.30"
           - "5.32"
+          - "5.36"
+          - "5.38"
+          - "5.40"
+          - "5.42"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}
     steps:
       - name: set up perl

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -160,8 +160,6 @@ jobs:
       matrix:
         os: [windows-latest]
         perl-version:
-          - "5.24"
-          - "5.26"
           - "5.28"
           - "5.30"
     name: perl ${{ matrix.perl-version }} on ${{ matrix.os }}

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -122,11 +122,6 @@ jobs:
       matrix:
         os: [macos-latest]
         perl-version:
-          - "5.14"
-          - "5.16"
-          - "5.18"
-          - "5.20"
-          - "5.22"
           - "5.24"
           - "5.26"
           - "5.28"
@@ -165,9 +160,6 @@ jobs:
       matrix:
         os: [windows-latest]
         perl-version:
-          - "5.18"
-          - "5.20"
-          - "5.22"
           - "5.24"
           - "5.26"
           - "5.28"

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -104,10 +104,12 @@ jobs:
           name: build_dir
           path: .
       - name: install deps using cpm
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           args: "--with-suggests --with-recommends"
+          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
+          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
       - run: prove -lr t
         env:
           AUTHOR_TESTING: 1
@@ -145,10 +147,12 @@ jobs:
           name: build_dir
           path: .
       - name: install deps using cpm
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           args: "--with-suggests --with-recommends"
+          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
+          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
       - run: prove -lr t
         env:
           AUTHOR_TESTING: 1
@@ -182,10 +186,12 @@ jobs:
       - name: install IO::Socket::SSL > 2.024   # Windows tests fail with 2.024, so we are getting the ...
         run: cpm install -g IO::Socket::SSL@2.089  # ... latest version available at the time of writing
       - name: install deps using cpm
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           args: "--with-suggests --with-recommends --with-test"
+          # App::cpm v0.999.0+ requires Perl 5.24+; pin older Perls to the last compatible release.
+          version: ${{ matrix.perl-version <= '5.22' && '0.998003' || 'main' }}
       - run: prove -lr t
         env:
           AUTHOR_TESTING: 0

--- a/.github/workflows/dzil-build-and-test.yml
+++ b/.github/workflows/dzil-build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.36
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v3
       - name: Run Tests
@@ -33,7 +33,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.36
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v3 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- **Dependabot** (`.github/dependabot.yml`): new file. Weekly GitHub Actions updates with a 7-day cooldown, grouped into two rolling PRs (`major-updates` and `minor-and-patch`) so coordinated major bumps land atomically while routine bumps stay batched.
- **CI workflow** (`.github/workflows/dzil-build-and-test.yml`): six modernization transforms, one commit each, applied via the `kitchen-sink:tune-perl-ci` skill:
  1. `fail-fast: false` on every matrix job
  2. Extend Linux + macOS matrices through Perl 5.42
  3. Bump build/coverage to `perldocker/perl-tester:5.42`
  4. (no-op) `push:` was already restricted to `master`
  5. Workflow-level `concurrency:` cancel-in-progress block
  6. Standardize on `install-with-cpm@v2` with App::cpm pin for Perls ≤ 5.22
  7. Drop macOS/Windows tests for Perls < 5.24

## Test plan

- [ ] CI runs green on this PR (Linux matrix covers 5.10 → 5.42; macOS/Windows start at 5.24).
- [ ] Concurrency: pushing a new commit cancels the prior in-flight run.
- [ ] Dependabot opens a single `minor-and-patch` PR (not a flurry) on the next weekly tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)