### PR TITLE
Decode Transfer-Encoding: gzip response bodies incrementally

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Release history for {{$dist->name}}
 
 {{$NEXT}}
+    - Decode a "Transfer-Encoding: gzip" response body incrementally instead
+      of buffering the entire compressed body and decompressing it in one
+      pass. Each read now returns the just-decoded bytes, so a caller's read
+      cap applies on every read and peak memory tracks the read size rather
+      than the response size. (Olaf Alders)
 
 6.24      2025-08-29 11:21:58Z
     - Fix #84: Replace neverssl.com with example.com in live tests (GH#86)

--- a/lib/Net/HTTP/Methods.pm
+++ b/lib/Net/HTTP/Methods.pm
@@ -476,18 +476,11 @@ sub read_entity_body {
 		    die "Can't make inflator: $status" unless $i;
 		    $_ = sub { my $out; $i->inflate($_[0], \$out); $out }
 		}
-		elsif ($_ eq "gzip" && gunzip_ok()) {
-		    #require IO::Uncompress::Gunzip;
-		    my @buf;
-		    $_ = sub {
-			push(@buf, $_[0]);
-			return "" unless $_[1];
-			my $input = join("", @buf);
-			my $output;
-			IO::Uncompress::Gunzip::gunzip(\$input, \$output, Transparent => 0)
-			    or die "Can't gunzip content: $IO::Uncompress::Gunzip::GunzipError";
-			return \$output;
-		    };
+		elsif ($_ eq "gzip" && inflate_ok()) {
+		    #require Compress::Raw::Zlib;
+		    my ($i, $status) = Compress::Raw::Zlib::Inflate->new(WindowBits => Compress::Raw::Zlib::WANT_GZIP());
+		    die "Can't make inflator: $status" unless $i;
+		    $_ = sub { my $out; $i->inflate($_[0], \$out); $out }
 		}
 		elsif ($_ eq "identity") {
 		    $_ = sub { $_[0] };

--- a/t/te-gzip.t
+++ b/t/te-gzip.t
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Needs 'Compress::Raw::Zlib', 'IO::Compress::Gzip';
+
+plan tests => 5;
+
+my $CRLF = "\015\012";
+
+# A payload large enough to span many reads and to be split across several
+# transfer-encoding chunks.
+my $payload = join('', map { "line $_: the quick brown fox jumps over the lazy dog\n" } 1 .. 500);
+
+my $gzipped;
+IO::Compress::Gzip::gzip(\$payload, \$gzipped)
+    or die "gzip failed: $IO::Compress::Gzip::GzipError";
+
+# Encode the gzip stream as several chunks so decoding must happen
+# incrementally across chunk boundaries.
+my $chunked = '';
+my $offset = 0;
+while ($offset < length($gzipped)) {
+    my $piece = substr($gzipped, $offset, 7);
+    $offset += length($piece);
+    $chunked .= sprintf('%x', length($piece)) . $CRLF . $piece . $CRLF;
+}
+$chunked .= '0' . $CRLF . $CRLF;
+
+our $response =
+    "HTTP/1.1 200 OK${CRLF}Transfer-Encoding: gzip, chunked${CRLF}${CRLF}" . $chunked;
+
+{
+    package HTTP;
+    use base 'Net::HTTP::Methods';
+
+    sub http_connect {
+	my ($self, $cnf) = @_;
+	${*$self}{out} = $main::response;
+	${*$self}{read_chunk_size} = $cnf->{ReadChunkSize};
+	return $self;
+    }
+
+    sub print { return 1 }
+
+    sub sysread {
+	my $self = shift;
+	my $length = $_[1];
+	my $offset = $_[2] || 0;
+
+	if (my $read_chunk_size = ${*$self}{read_chunk_size}) {
+	    $length = $read_chunk_size if $read_chunk_size < $length;
+	}
+
+	my $data = substr(${*$self}{out}, 0, $length, '');
+	return 0 unless length($data);
+
+	$_[0] = '' unless defined $_[0];
+	substr($_[0], $offset) = $data;
+	return length($data);
+    }
+}
+
+my $h = HTTP->new(Host => 'gzip', KeepAlive => 1, ReadChunkSize => 5) || die;
+$h->write_request('GET', '/');
+my ($code) = $h->read_response_headers;
+is($code, 200, 'response parsed');
+
+my $content = '';
+my $max_return = 0;
+my $length_always_truthful = 1;
+my $tmp;
+my $n;
+# read_entity_body returns -1 as a "read again" sentinel when a decoder has
+# consumed input but not yet produced output; only positive returns carry bytes.
+while ($n = $h->read_entity_body($tmp, 40)) {
+    if ($n > 0) {
+	# A body-of-any-size returning a stringified reference (~19 bytes)
+	# instead of the real decoded bytes would show up here as a length that
+	# does not match the bytes actually appended to the buffer.
+	$length_always_truthful = 0 if $n != length($tmp);
+	$max_return = $n if $n > $max_return;
+	$content .= $tmp;
+    }
+}
+
+is($content, $payload, 'gzip transfer-encoding decoded correctly');
+ok($length_always_truthful, 'returned length matches the decoded bytes on every read');
+ok($max_return > 0, 'at least one read produced decoded bytes');
+
+# No single read yielded the whole body: decoding streams incrementally rather
+# than buffering the entire response and releasing it in one go.
+cmp_ok($max_return, '<', length($payload), 'body delivered incrementally, not all at once');


### PR DESCRIPTION
## Summary

`Net::HTTP::Methods::read_entity_body` handled a `Transfer-Encoding: gzip`
response body by accumulating every de-chunked byte in a closure-local buffer
and gunzipping the whole thing in a single pass once the terminating
zero-length chunk arrived, then returning a scalar **reference** to the result.

That has two problems:

1. **The read cap is never consulted while the body streams.** Each read
   returned `""` (surfaced upstream as `-1`, "read again"), so the buffer grew
   with no upper bound until the stream ended. A caller's read/size cap — e.g.
   `LWP::UserAgent`'s `max_size`, enforced in `LWP::Protocol::collect` — only
   sees the body *after* it has already been fully buffered and decompressed,
   which defeats the point of the cap. Compression ratios stack on top of this.

2. **Size accounting is wrong.** Because the closure returned a reference,
   `length()` measured the stringified reference (~19 bytes) rather than the
   decoded payload.

## Fix

Decode incrementally with `Compress::Raw::Zlib::Inflate->new(WindowBits => WANT_GZIP)`,
mirroring the `deflate` branch immediately above it. Each read now returns a
plain string of just-decoded bytes, so:

- `length()` is truthful,
- a caller's read cap applies on every read, and
- peak memory tracks the read size instead of the whole response size.

## Tests

- New `t/te-gzip.t` builds a `gzip, chunked` response split across many small
  chunks and asserts correct decoding, truthful per-read lengths, and
  incremental delivery. It fails against the previous code (returns a
  `SCALAR(0x…)`) and passes with this change.
- Existing `t/http.t` and `t/socket-class.t` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)